### PR TITLE
[조원빈/230911]_카드 섞기

### DIFF
--- a/src/main/wonbin/day230906/후보_추천하기.java
+++ b/src/main/wonbin/day230906/후보_추천하기.java
@@ -16,7 +16,7 @@ import java.util.*;
 
  */
 
-public class 후보 {
+public class 후보_추천하기 {
 
     static class Student implements Comparable<Student> {
         // 각각 후보의 추천수, 숫자, 등록 시간

--- a/src/main/wonbin/day230907/기차가_어둠을_헤치고_은하수를_ver1.java
+++ b/src/main/wonbin/day230907/기차가_어둠을_헤치고_은하수를_ver1.java
@@ -1,0 +1,84 @@
+package main.wonbin.day230907;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/*
+    [시뮬레이션]_백준_15787_기차가 어둠을 헤치고 은하수를
+    
+    기차를 리스트로 만들고 리스트 index로 각 좌석을 구현하였지만
+    총 10만 개의 리스트가 만들어질 수 있어서 메모리를 과다하게 사용하였다.
+    
+ */
+public class 기차가_어둠을_헤치고_은하수를_ver1 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        // 기차를 저장할 리스트
+        ArrayList<ArrayList<Integer>> lists = new ArrayList<>();
+
+        int temp[] = new int[20];
+
+        for (int i = 0; i < N; i++) {
+            
+            // 각 기차를 빈 좌석 20개의 리스트로 채움
+            ArrayList<Integer> tp = (ArrayList<Integer>) (Arrays.stream(temp).boxed().collect(Collectors.toList()));
+            lists.add(tp);
+        }
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            // 명령어
+            int order = Integer.parseInt(st.nextToken());
+            
+            // 기차 넘버
+            int numberOfTrain = Integer.parseInt(st.nextToken()) - 1;
+            
+            // 각 명령어 이행
+            if (order == 1) {
+                // 기차 좌석
+                int target = Integer.parseInt(st.nextToken()) - 1;
+                lists.get(numberOfTrain).set(target, 1);
+            } else if (order == 2) {
+                int target = Integer.parseInt(st.nextToken()) - 1;
+                lists.get(numberOfTrain).set(target, 0);
+            } else if (order == 3) {
+                lists.get(numberOfTrain).remove(lists.get(numberOfTrain).size() - 1);
+                lists.get(numberOfTrain).add(0, 0);
+            } else {
+                lists.get(numberOfTrain).remove(0);
+                lists.get(numberOfTrain).add(0);
+            }
+        }
+
+        // 기차 각 좌석의 사람을 이진수로 계산하여 중복체크
+        Set<Integer> set = new HashSet<>();
+        int result = 0;
+
+        for (int i = 0; i < N; i++) {
+            int binary = 0;
+            for (int j = 0; j < 20; j++) {
+                if (lists.get(i).get(j) == 0)
+                    continue;
+                binary += (int) Math.pow(2, 19 - j);
+            }
+            if (!set.contains(binary)) {
+                result++;
+            }
+            set.add(binary);
+        }
+
+        System.out.println(result);
+        br.close();
+    }
+
+}

--- a/src/main/wonbin/day230907/기차가_어둠을_헤치고_은하수를_ver2.java
+++ b/src/main/wonbin/day230907/기차가_어둠을_헤치고_은하수를_ver2.java
@@ -1,0 +1,70 @@
+package main.wonbin.day230907;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/*
+    [시뮬레이션]_백준_15787_기차가 어둠을 헤치고 은하수를
+
+    기차를 배열에 이진수값으로 저장하였다. 리스트로 만든 것보다
+    메모리는 3배 적게 사용했고, 시간도 반으로 줄었다.
+
+ */
+public class 기차가_어둠을_헤치고_은하수를_ver2 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        // 기차를 이진수 값으로 저장할 배열
+        int trains[] = new int[N];
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            // 명령어
+            int order = Integer.parseInt(st.nextToken());
+            // 기차 넘버
+            int numberOfTrain = Integer.parseInt(st.nextToken()) - 1;
+
+            // 각 명령어 이행
+            if (order == 1) {
+                int target = Integer.parseInt(st.nextToken()) - 1;
+                trains[numberOfTrain] |= (1 << target);
+            } else if (order == 2) {
+                int target = Integer.parseInt(st.nextToken()) - 1;
+                trains[numberOfTrain] &= ~(1 << target);
+            } else if (order == 3) {
+                // 마지막 좌석이 차있는 경우 삭제
+                if ((trains[numberOfTrain] & (1 << 19)) != 0)
+                    trains[numberOfTrain] &= ~(1 << 19);
+                trains[numberOfTrain] <<= 1;
+            } else {
+                // 첫 좌석이 차있는 경우 삭제
+                if ((trains[numberOfTrain] & 1) != 0)
+                    trains[numberOfTrain] &= ~1;
+                trains[numberOfTrain] >>= 1;
+            }
+        }
+
+        // 중복 체크
+        Set<Integer> set = new HashSet<>();
+        int result = 0;
+
+        for (int i = 0; i < N; i++) {
+            if (!set.contains(trains[i])) {
+                result++;
+            }
+            set.add(trains[i]);
+        }
+
+        System.out.println(result);
+        br.close();
+    }
+}

--- a/src/main/wonbin/day230908/와드.java
+++ b/src/main/wonbin/day230908/와드.java
@@ -1,0 +1,158 @@
+package main.wonbin.day230908;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+/*
+    [시뮬레이션]_백준_23747_와드
+
+    시야가 보이는 곳을 탐색하는 문제로 BFS로 구현하였다.
+    처음에 같은 알파벳이 인접해있지 않아도 같은 구역이라 생각하고 구현하였는데
+    다른 구역이었다. 문제를 잘 읽자.
+
+ */
+
+public class 와드 {
+    static class Point {
+        int x, y;
+
+        Point(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    static int row, col;
+    // 순서대로 상/하/좌/우/가운데
+    static int dx[] = {-1, 1, 0, 0, 0};
+    static int dy[] = {0, 0, -1, 1, 0};
+    static char map[][];
+    static boolean visiblePoint[][];
+    static Queue<Point> q = new LinkedList<>();
+    static Queue<Point> points = new LinkedList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        row = Integer.parseInt(st.nextToken());
+        col = Integer.parseInt(st.nextToken());
+
+        // 구역을 저장할 배열
+        map = new char[row][col];
+        // 시야가 보이는 곳을 저장할 배열
+        visiblePoint = new boolean[row][col];
+
+        for (int i = 0; i < row; i++) {
+            String temp = br.readLine();
+
+            for (int j = 0; j < col; j++) {
+                map[i][j] = temp.charAt(j);
+            }
+        }
+
+        st = new StringTokenizer(br.readLine());
+        // 시작 인덱스
+        int x = Integer.parseInt(st.nextToken()) - 1;
+        int y = Integer.parseInt(st.nextToken()) - 1;
+
+        String way = br.readLine();
+
+        warding(x, y, way);
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < row; i++) {
+            for (int j = 0; j < col; j++) {
+                if (visiblePoint[i][j]) {
+                    sb.append('.');
+                } else
+                    sb.append('#');
+            }
+            sb.append("\n");
+        }
+
+        System.out.println(sb);
+        br.close();
+    }
+
+    // 와드를 설치한 곳과 같은 구역을 돌아다니며 시야를 밝혀주는 메소드
+    private static void bfs(int x, int y, char alpa) {
+
+        points.add(new Point(x, y));
+        visiblePoint[x][y] = true;
+
+        // 사방 탐색을 하면서 와드가 설치된 곳과 같은 구역 찾기
+        while (!points.isEmpty()) {
+            Point now = points.poll();
+
+            for (int i = 0; i < 4; i++) {
+                int nx = now.x + dx[i];
+                int ny = now.y + dy[i];
+
+                if (nx < 0 || ny < 0 || nx >= row || ny >= col)
+                    continue;
+                if (visiblePoint[nx][ny])
+                    continue;
+                if (map[nx][ny] != alpa)
+                    continue;
+
+                visiblePoint[nx][ny] = true;
+                points.add(new Point(nx, ny));
+            }
+        }
+    }
+
+    // 돌아다니며 와드를 박는 메소드
+    private static void warding(int startX, int startY, String way) {
+        q.add(new Point(startX, startY));
+
+        int index = 0;
+        while (index < way.length()) {
+
+            Point now = q.poll();
+
+            // 다음에 움직일 방향
+            char dir = way.charAt(index);
+            int intDir = 4;
+            switch (dir) {
+                case 'W':
+                    // 방향이 와드면 같은 구역에 와드를 설치함
+                    if (!visiblePoint[now.x][now.y])
+                        bfs(now.x, now.y, map[now.x][now.y]);
+                    break;
+                case 'U':
+                    intDir = 0;
+                    break;
+                case 'D':
+                    intDir = 1;
+                    break;
+                case 'L':
+                    intDir = 2;
+                    break;
+                case 'R':
+                    intDir = 3;
+                    break;
+
+            }
+            // 다음 좌표를 큐에 넣고 갱신해줌.
+            q.add(new Point(now.x + dx[intDir], now.y + dy[intDir]));
+
+            index++;
+
+        }
+
+        // 마지막 위치에서는 상/하/좌/우/가운데 방향을 볼 수 있게 처리
+        Point lastPoint = q.poll();
+        for (int i = 0; i < 5; i++) {
+            int nx = lastPoint.x + dx[i];
+            int ny = lastPoint.y + dy[i];
+
+            if (nx < 0 || ny < 0 || nx >= row || ny >= col)
+                continue;
+            visiblePoint[nx][ny] = true;
+        }
+    }
+}

--- a/src/main/wonbin/day230911/카드_섞기.java
+++ b/src/main/wonbin/day230911/카드_섞기.java
@@ -1,0 +1,134 @@
+package main.wonbin.day230911;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.StringTokenizer;
+
+/*
+    [시뮬레이션]_백준_21315_카드 섞기
+
+    섞을 카드의 수가 최대 1000장이고 2^10 미만이므로 완전 탐색이 가능하다 생각했다.
+    N장의 카드 수보다 작은 2^(1~K) 범위를 구했고, 두 번에 걸쳐 섞어주는 코드를 구현했다.
+    K가 큰 수 부터 작은 수로 내려오는 방식의 메소드와 작은 수 부터 큰 수로 올라가는 메소드를 각각 구현했다.
+    하지만 메모리나 시간 상 큰 차이는 없었다.
+
+    이 문제의 핵심은 카드 덱 맨 아래에 있는 카드는 반드시 맨 위로 올라오게 된다는 것이다.
+ */
+
+public class 카드_섞기 {
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        // 최종 결과값 비교 배열
+        int answer[] = new int[N];
+
+        for (int i = 0; i < N; i++) {
+            answer[i] = Integer.parseInt(st.nextToken());
+        }
+
+        // 1부터 N까지 차례로 저장할 리스트
+        ArrayList<Integer> nonMixedCard = new ArrayList<>();
+        int num = 1;
+        while (num <= N) {
+            nonMixedCard.add(num++);
+        }
+
+        // 각각 카드 섞기에서 나온 결과값 저장 리스트
+        ArrayList<Integer> firstMixedCard;
+        ArrayList<Integer> lastMixedCard;
+
+        // 최대로 가질 수 있는 2의 지수값 찾기
+        int maxK = findPossibleMixingK(N);
+
+        // 1~maxK 까지 완전 탐색
+        for (int i = 1; i <= maxK; i++) {
+            firstMixedCard = mixed2_K_ver2(i, N, (ArrayList<Integer>) nonMixedCard.clone());
+
+            for (int j = 1; j <= maxK; j++) {
+                lastMixedCard = mixed2_K_ver2(j, N, (ArrayList<Integer>) firstMixedCard.clone());
+
+                // 최종 값과 비교하여 모두 같으면 출력
+                boolean isEquals = true;
+                for (int z = 0; z < N; z++) {
+                    if (answer[z] != lastMixedCard.get(z)) {
+                        isEquals = false;
+                    }
+                }
+                if (isEquals) {
+                    System.out.println(i + " " + j);
+                    return;
+                }
+            }
+        }
+
+
+        br.close();
+    }
+
+    // 최대로 가질 수 있는 2의 지수값 찾기 메소드
+    private static int findPossibleMixingK(int N) {
+        int cnt = 9;
+        while (cnt >= 1) {
+            if (Math.pow(2, cnt) <= N)
+                return cnt;
+            cnt--;
+        }
+        return cnt;
+    }
+
+    // 2의 지수가 작은 수부터 큰 수로 갈 때, 카드 섞기 메소드
+    private static ArrayList<Integer> mixed2_K_ver2(int K, int N, ArrayList<Integer> card) {
+
+        ArrayList<Integer> result = new ArrayList<>();
+        int cnt = 1;
+        int index = N - 1;
+        result.add(card.get(N - 1));
+        while (cnt <= K) {
+            int mixedCardListSize = (int) Math.pow(2, cnt);
+            for (int i = N - mixedCardListSize; i < index; i++) {
+                result.add(card.get(i));
+            }
+            index = N - mixedCardListSize;
+            cnt++;
+        }
+        for (int i = 0; i < index; i++) {
+            result.add(card.get(i));
+        }
+        return result;
+    }
+
+    // 2의 지수가 큰 수부터 작은 수로 갈 때, 카드 섞기 메소드
+    private static ArrayList<Integer> mixed2_K_Ver1(int K, int N, ArrayList<Integer> card) {
+
+        ArrayList<Integer> result = new ArrayList<>();
+        int mixedCardListSize = (int) Math.pow(2, K);
+        for (int i = N - mixedCardListSize - 1; i >= 0; i--) {
+            result.add(card.get(i));
+        }
+        int index = N - mixedCardListSize;
+
+        while (K >= 0) {
+
+            mixedCardListSize = (int) Math.pow(2, K);
+
+
+            for (int i = index + mixedCardListSize / 2 - 1; i >= index; i--) {
+                result.add(card.get(i));
+            }
+            index += mixedCardListSize / 2;
+            K--;
+        }
+        result.add(card.get(index));
+        Collections.reverse(result);
+        return result;
+    }
+}


### PR DESCRIPTION
[시뮬레이션]_백준_21315_카드 섞기

    섞을 카드의 수가 최대 1000장이고 2^10 미만이므로 완전 탐색이 가능하다 생각했다.
    N장의 카드 수보다 작은 2^(1~K) 범위를 구했고, 두 번에 걸쳐 섞어주는 코드를 구현했다.
    K가 큰 수 부터 작은 수로 내려오는 방식의 메소드와 작은 수 부터 큰 수로 올라가는 메소드를 각각 구현했다.
    하지만 메모리나 시간 상 큰 차이는 없었다.

    이 문제의 핵심은 카드덱 맨 아래에 있는 카드는 반드시 맨 위로 올라오게 된다는 것이다.